### PR TITLE
Update docker build script to use bash

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Used to build/rebuild the Docker container.
 


### PR DESCRIPTION
The docker build script uses bash-specific features. On Debian, `/bin/sh` symlinks to `dash` (which only supports POSIX sh features), causing `./docker-build.sh` to fail.