### PR TITLE
Memory Failure Fix For docker-analyze

### DIFF
--- a/docker-analyze.sh
+++ b/docker-analyze.sh
@@ -100,6 +100,7 @@ fi
 docker run --rm \
        -v $PROGRAM_DIR:/root/program \
        -v $ANALYSIS_DIR:/root/analysis \
+       --ulimit nofile=262144:262144 \
        ${DOCKER_IMAGE_NAME}:latest \
        bash -c \
        "(cd /root/program; \


### PR DESCRIPTION
This was originally a fix for manjaro devices but was placed in the build.sh instead of analyze.sh